### PR TITLE
Upgrading to newer versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN set -ex \
         nss@edge \
     && rm -rf /tmp/* /var/cache/apk/*
 
-# Puppeteer v0.11.0 works with Chromium 63.
-RUN yarn add puppeteer@0.11.0 mermaid.cli@0.5.1
+RUN /usr/bin/chromium-browser --version 
+
+# Puppeteer v0.13.0 works with Chromium 64.
+RUN yarn add puppeteer@0.13.0 mermaid.cli@0.5.1
 
 RUN mkdir /cfg
 ADD puppeteer.json /cfg/puppeteer.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,10 @@ RUN set -ex \
     && rm -rf /tmp/* /var/cache/apk/*
 
 # Puppeteer v0.11.0 works with Chromium 63.
-RUN yarn add puppeteer@0.11.0 mermaid.cli@0.3.1
+RUN yarn add puppeteer@0.11.0 mermaid.cli@0.5.1
 
-# Fixing location of Chrome executable.
-RUN sed -i "63s#puppeteer.launch()#puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], executablePath: '/usr/bin/chromium-browser'})#g" \
-    /node_modules/mermaid.cli/index.bundle.js
+RUN mkdir /cfg
+ADD puppeteer.json /cfg/puppeteer.json
 
 # Symlink to PATH.
 RUN ln -sf /node_modules/mermaid.cli/index.bundle.js /usr/local/bin/mmdc
@@ -29,4 +28,5 @@ RUN ln -sf /node_modules/mermaid.cli/index.bundle.js /usr/local/bin/mmdc
 # Create data directory.
 RUN mkdir -p ${DATA_DIRECTORY}
 
-CMD ["mmdc"]
+ENTRYPOINT ["mmdc", "--puppeteerConfigFile", "/cfg/puppeteer.json"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.5.0-alpine
+FROM node:10.7.0-alpine
 
 # Create /data dir where files can be read/written.
 ENV \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # docker-mermaid-cli
 Docker image for the Mermaid CLI utility. Useful for generating diagrams written in Mermaid JS.
+
+## Sample usage:
+```sh
+docker run -v $PWD:/data colega/mermaid-cli --cssFile /data/mermaid.css -i /data/diagram.mmd
+```

--- a/puppeteer.json
+++ b/puppeteer.json
@@ -1,0 +1,7 @@
+{
+    "args": [
+        "--no-sandbox",
+        "--disable-setuid-sandbox"
+    ],
+    "executablePath": "/usr/bin/chromium-browser"
+}


### PR DESCRIPTION
Now this uses the latest `node` and `mermaid.cli` versions, and also upgraded to `puppeteer@0.13.0` which works with Chromium 64 which is the latest available now in alpine.